### PR TITLE
InterfaceParameter Alfred

### DIFF
--- a/announce.sh
+++ b/announce.sh
@@ -8,7 +8,7 @@ while test $# -gt 0; do
       shift
       ip link show dev $1 > /dev/null
       test $? -ne 0 && exit
-      INTERFACE="-I $1"
+      INTERFACE="-i $1"
       ;;
     -b)
       shift


### PR DESCRIPTION
http://mirror.fluxent.de/archlinux-custom/freifunk-rheinland/os/x86_64/

Bei mit Funktioniert der Parameter aufruf `-I` nur mit ein kleinen `-i`.
Muss ggf. mit der Debian Version und der Produktiv-Version überprüft werden.