### PR TITLE
add node_id in statistics - for new meshviewer

### DIFF
--- a/statistics.d/node_id
+++ b/statistics.d/node_id
@@ -1,0 +1,1 @@
+open('/sys/class/net/' + batadv_dev + '/address').read().strip().replace(':', '')


### PR DESCRIPTION
node_id nicht nur in nodeinfo.d:
https://github.com/ffnord/ffnord-alfred-announce/commit/84385d8f3602ed6dda40467d3f55876b707a8f45

sonder entsprechend der gluon auch in statiscits.d:
https://github.com/freifunk-gluon/packages/blob/master/gluon/gluon-announce/files/lib/gluon/announce/statistics.d/node_id