### PR TITLE
node_id symlink for statistics

### DIFF
--- a/statistics.d/node_id
+++ b/statistics.d/node_id
@@ -1,0 +1,1 @@
+../nodeinfo.d/node_id


### PR DESCRIPTION
node_id nicht nur in nodeinfos
https://github.com/ffnord/ffnord-alfred-announce/commit/84385d8f3602ed6dda40467d3f55876b707a8f45

sonder entsprechend der gluon auch in statiscits.d:
https://github.com/freifunk-gluon/packages/blob/master/gluon/gluon-announce/files/lib/gluon/announce/statistics.d/node_id

Damit Meshviewer auch die Statistiken Anzeigt.
https://github.com/tcatm/meshviewer

----
Achtung dies ist nur ein symlink, implementierungsvariante von node_id bitte in #7 diskutieren