### PR TITLE
Optimizing gzip parameters

### DIFF
--- a/announce.sh
+++ b/announce.sh
@@ -2,6 +2,7 @@
 
 DIR="$(dirname "$0")"
 SOCKET=""
+GZIP="-cn9"
 
 while test $# -gt 0; do
   case $1 in
@@ -29,5 +30,5 @@ while test $# -gt 0; do
   shift
 done
 
-"${DIR}"/announce.py -d "${DIR}"/nodeinfo.d/ ${BATADV} | gzip | alfred $INTERFACE $SOCKET -s 158
-"${DIR}"/announce.py -d "${DIR}"/statistics.d/ ${BATADV} | gzip | alfred $INTERFACE $SOCKET -s 159
+"${DIR}"/announce.py -d "${DIR}"/nodeinfo.d/ ${BATADV} | GZIP=$GZIP gzip | alfred $INTERFACE $SOCKET -s 158
+"${DIR}"/announce.py -d "${DIR}"/statistics.d/ ${BATADV} | GZIP=$GZIP gzip| alfred $INTERFACE $SOCKET -s 159


### PR DESCRIPTION
The flags -n, -c and -9 were added to the invocation of gzip. With
the statistics directory, this led to an apparent reduction of 1 byte
over the default settings. With the ASCII encoding in JSON the effect will
be increased. Also the size of information stored is likely to increase,
which further motivates to become more ambitious in compression.

The meaning of the parameters is

 -9 (or --best): best possible encryption
 -n            : do not store name etc of filenames, also not any temporary ones
 -c            : use the stdio

It is not unlikely that -n (likely) and -c (very likely) are both
implicitly set. Anyway.