### PR TITLE
ipaddress module is only available for python 3.3+

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ These scripts are replacements for the *[respondd]* and *[gluon-alfred]* package
 
  * lsb\_release
  * ethtool
- * python3
+ * python3 (>= 3.3)
  * If using alfred: alfred binary in PATH
 
 ## Setup


### PR DESCRIPTION
The downside is that this excludes Debian oldstable from the range of supported platforms since this only hosts Python3.2. This is sad news for some folks that are still stuck with batman v14.