### PR TITLE
respondd.service: Add default + debian path for batctl

### DIFF
--- a/respondd.service
+++ b/respondd.service
@@ -4,7 +4,7 @@ Description=Respondd
 [Service]
 ExecStart=/opt/ffnord-alfred-announce/respondd.py
 Restart=always
-Environment=PATH=/usr/bin:/usr/local/bin
+Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
batctl is installed by default under /usr/local/sbin. Debian overwrites this to conform with the Debian policy and installs it under /usr/sbin/. So having these in the PATH environment variable is necessary to get nodeinfo.d/network/mesh to work properly.